### PR TITLE
fix issue with regular expression from config getting lost

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ var ENV = {
   oembed: {
     providers: {
       mysite: {
-        regex: /www.mysite.com\/thing/g,
+        regex: {
+          pattern: 'www.mysite.com\/thing',
+          flags: 'g',
+        }
         providerUrl: 'http://mysite.com/oembed',
         defaultParams: {
           format: 'json'

--- a/app/services/oembed.js
+++ b/app/services/oembed.js
@@ -6,6 +6,15 @@ function findProvider(url, providers) {
   for (let i in providers) {
     if (providers.hasOwnProperty(i)) {
       let prov = providers[i];
+      if(prov.regex.hasOwnProperty('pattern')) {
+        if(prov.regex.hasOwnProperty('flags')) {
+          prov.regex = new RegExp(prov.regex.pattern, prov.regex.flags);
+        }
+        else {
+          prov.regex = new RegExp(prov.regex.pattern);
+        }
+      }
+
       if (prov.regex.test(url)) {
         return prov;
       }


### PR DESCRIPTION
This is an attempt to resolve #36.  In https://github.com/emberjs/ember.js/issues/13593, someone suggested working around that limitation of ember by storing the regular expression as an object with properties for the pattern and flags. 

This change allows that syntax for config-defined providers and creates a RegExp from that object if that syntax is used.